### PR TITLE
Fix "[StochasticMtx] Avoid NaN with 0-weight edges (#4)"

### DIFF
--- a/src/sparsematrix.cpp
+++ b/src/sparsematrix.cpp
@@ -34,7 +34,18 @@ uint32_t makeStochastic(sparse_matrix P){
 
     for ( uint32_t t = P.col [j] ; t < P.col[j+1] ; t++) 
       sum += P.val[t];
-    
+
+    if ( sum == 0.0 && P.val[P.col[j]] == 0.0 ) {
+#ifdef VERBOSE
+      std::cerr << "WARNING: Explicit zero weight"
+                << " [(i,j)=(" << P.row[P.col[t]] << "," << j << ")"
+                << " in a zero-sum row."
+                << "Skipping stochastic rescaling of row."
+                << std::endl;
+#endif
+      continue;
+    }
+
     if ( std::abs(sum - 1) > 1e-12 )
       for ( uint32_t t = P.col [j] ; t < P.col [j+1] ; t++) 
         P.val[t] /= sum;

--- a/src/sparsematrix.cpp
+++ b/src/sparsematrix.cpp
@@ -35,23 +35,23 @@ uint32_t makeStochastic(sparse_matrix P){
     for ( uint32_t t = P.col [j] ; t < P.col[j+1] ; t++) 
       sum += P.val[t];
 
-    if ( sum == 0.0 && P.val[P.col[j]] == 0.0 ) {
+    if ( sum != 0.0 || P.val[P.col[j]] != 0.0 ) {
+      if ( std::abs(sum - 1) > 1e-12 )
+        for ( uint32_t t = P.col [j] ; t < P.col [j+1] ; t++)
+          P.val[t] /= sum;
+      else
+        stoch[j] = 1;
+    }
 #ifdef VERBOSE
+    else {
       std::cerr << "WARNING: Explicit zero weight"
                 << " [(i,j)=(" << P.row[P.col[t]] << "," << j << ")"
                 << " in a zero-sum row."
                 << "Skipping stochastic rescaling of row."
                 << std::endl;
-#endif
-      continue;
     }
+#endif
 
-    if ( std::abs(sum - 1) > 1e-12 )
-      for ( uint32_t t = P.col [j] ; t < P.col [j+1] ; t++) 
-        P.val[t] /= sum;
-    else
-      stoch[j] = 1;
-    
   }
 
   uint32_t nStoch = 0;

--- a/src/sparsematrix.cpp
+++ b/src/sparsematrix.cpp
@@ -34,18 +34,7 @@ uint32_t makeStochastic(sparse_matrix P){
 
     for ( uint32_t t = P.col [j] ; t < P.col[j+1] ; t++) 
       sum += P.val[t];
-
-    if ( sum == 0.0 && P.val[P.col[j]] == 0.0 ) {
-#ifdef VERBOSE
-      std::cerr << "WARNING: Explicit zero weight"
-                << " [(i,j)=(" << P.row[P.col[t]] << "," << j << ")"
-                << " in a zero-sum row."
-                << "Skipping stochastic rescaling of row."
-                << std::endl;
-#endif
-      continue;
-    }
-
+    
     if ( std::abs(sum - 1) > 1e-12 )
       for ( uint32_t t = P.col [j] ; t < P.col [j+1] ; t++) 
         P.val[t] /= sum;


### PR DESCRIPTION
Reverts fcdimitr/sgtsnepi#5.

That PR introduced a bug when compiling SG-t-SNE-Π with `g++` 7.5.0 and Intel Cilk Plus: the `continue` statement inside a `cilk_for` loop causes a compilation error.