### PR TITLE
Expose learning rate parameter

### DIFF
--- a/src/demo_stochastic_matrix.cpp
+++ b/src/demo_stochastic_matrix.cpp
@@ -42,13 +42,16 @@ int main(int argc, char **argv)
   // Shut GetOpt error messages down (return '?'): 
   opterr = 0;
 
-  while ( (opt = getopt(argc, argv, "l:d:a:m:e:h:p:")) != -1 ) { 
+  while ( (opt = getopt(argc, argv, "l:d:a:m:e:h:p:r")) != -1 ) {
     switch ( opt ) {
     case 'l':
       sscanf(optarg, "%lf", &params.lambda);
       break;
     case 'd':
       params.d = atoi(optarg);
+      break;
+    case 'r':
+      params.eta = atoi(optarg);
       break;
     case 'm':
       params.maxIter = atoi(optarg);

--- a/src/demo_stochastic_matrix.cpp
+++ b/src/demo_stochastic_matrix.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
       params.d = atoi(optarg);
       break;
     case 'r':
-      params.eta = atoi(optarg);
+      sscanf(optarg, "%lf", &params.eta);
       break;
     case 'm':
       params.maxIter = atoi(optarg);

--- a/src/gradient_descend.cpp
+++ b/src/gradient_descend.cpp
@@ -130,7 +130,7 @@ void kl_minimization(coord* y,
   // ----- t-SNE hard coded parameters - Same as in vdM's code
   int    stop_lying_iter = params.earlyIter, mom_switch_iter = 250;
   double momentum = .5, final_momentum = .8;
-  double eta    = 200.0;
+  double eta    = params.eta;
   int    iterPrint = 50;
   
   double timeFattr = 0.0;

--- a/src/sgtsne.hpp
+++ b/src/sgtsne.hpp
@@ -33,8 +33,8 @@ typedef struct {
   double h         = -1;        //!< Grid side length (accuracy control)
   bool   dropLeaf  = false;     //!< Drop edges originating from leaf nodes?
   int    np        = 0;         //!< Number of CILK workers (processes)
-  
-} tsneparams; 
+  double eta       = 200.0;     //!< learning rate
+} tsneparams;
 
 
 //! Sparse matrix structure in CSC format

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -22,6 +22,7 @@ void printParams(tsneparams P){
             << "Early exag. multiplier α: " << P.alpha << std::endl
             << "Maximum iterations: " << P.maxIter << std::endl
             << "Early exag. iterations: " << P.earlyIter << std::endl
+            << "Learning rate: " << P.eta << std::endl
             << "Box side length h: " << P.h << std::endl
             << "Drop edges originating from leaf nodes? " << P.dropLeaf << std::endl
             << "Number of processes: " << P.np << std::endl;


### PR DESCRIPTION
This pull request resolves the following comment  from @parashardhapola 

> Hi, 
> 
> I found that learning rate parameter (eta) in the KL minimization step (`gradient_descend.cpp`) has not been exposed and is hard coded to `200`.
> Is it possible to expose it in `sgtsne` (`sgtsne.cpp`) and also in `demo_stochastic_matrix.cpp`?
> 
> Learning rate is a crucial parameter for obtaining high quality data embedding and it will be nice to give user the ability to increase the value for larger datasets. The paper below has a nice discussion about this:
> https://www.nature.com/articles/s41467-019-13056-x
> 
> Thanks
> 
> Best regards,
> Parashar
