### PR TITLE
Added python test script 

### DIFF
--- a/python/test_digits.py
+++ b/python/test_digits.py
@@ -1,5 +1,5 @@
 ## test_digits.py
-# Test 3D SG-t-SNE embedding with 
+# Test 3D SG-t-SNE embedding 
 
 ## download the matrix and label file from Tim Davids' matrix collection
 import requests

--- a/python/test_digits.py
+++ b/python/test_digits.py
@@ -1,0 +1,78 @@
+## test_digits.py
+# Test 3D SG-t-SNE embedding with 
+
+## download the matrix and label file from Tim Davids' matrix collection
+import requests
+url = "https://suitesparse-collection-website.herokuapp.com/MM/ML_Graph/optdigits_10NN.tar.gz"
+r = requests.get(url, allow_redirects=True)
+open('optdigits_10NN.tar.gz', 'wb').write(r.content)
+
+
+## unzip to the current folder
+import tarfile
+
+tar = tarfile.open('./optdigits_10NN.tar.gz', 'r:gz')
+tar.extractall()
+tar.close()
+
+## reading out the matrix and the label
+from scipy.io import mmread
+from scipy.sparse import csc_matrix
+
+A = mmread('./optdigits_10NN/optdigits_10NN.mtx')
+A = csc_matrix(A)
+L = mmread('./optdigits_10NN/optdigits_10NN_label.mtx')
+L = csc_matrix(L).toarray()
+
+## SG-tSNE-Π setup
+# setup julia
+from julia.api import Julia
+jl = Julia(compiled_modules=False)
+
+# add current path
+import sys
+sys.path.insert(0,"./")
+
+# make sure that the sgtsnepi.py is in the current 
+# script_url = "https://raw.githubusercontent.com/fcdimitr/sgtsnepi/julia-python-packages/python/sgtsnepi.py";
+# r = requests.get(url, allow_redirects=True)
+# open('sgtsnepi.py', 'w').write(r.text)
+
+# generate the embedding
+from sgtsnepi import sgtsnepi
+Y = sgtsnepi(A, d = 3, λ = 10, max_iter = 500)
+
+# visualization
+import matplotlib.pyplot as plt
+from matplotlib.colors import ListedColormap
+import numpy as np
+
+# distinguishable color map (10 clusters)
+cmap = [[0.3000, 0.3000, 1.0000],
+[0.3000, 1.0000, 0.3000],
+[1.0000, 0.3000, 0.3000],
+[1.0000, 0.8552, 0.3000],
+[0.3000, 0.3000, 0.4931],
+[1.0000, 0.3000, 0.8069],
+[0.3000, 0.5655, 0.3000],
+[0.5897, 0.3966, 0.3000],
+[0.3000, 1.0000, 0.9034],
+[0.3000, 0.7586, 1.0000]];
+newcmap = ListedColormap(cmap)
+
+# draw scatter plot (3D)
+fig = plt.figure()
+ax = fig.add_subplot(projection='3d')
+
+ax.scatter(Y[:,0], Y[:,1], Y[:,2], c=L, marker='.', cmap=newcmap)
+
+ax.set_xlabel('X')
+ax.set_ylabel('Y')
+ax.set_zlabel('Z')
+
+plt.show()
+
+## AUTHOR
+# Tiancheng Liu <tcliu@cs.duke.edu>
+# Dimitris Foloros <fcdimitr@auth.gr>
+# 

--- a/python/test_digits.py
+++ b/python/test_digits.py
@@ -33,11 +33,6 @@ jl = Julia(compiled_modules=False)
 import sys
 sys.path.insert(0,"./")
 
-# make sure that the sgtsnepi.py is in the current 
-# script_url = "https://raw.githubusercontent.com/fcdimitr/sgtsnepi/julia-python-packages/python/sgtsnepi.py";
-# r = requests.get(url, allow_redirects=True)
-# open('sgtsnepi.py', 'w').write(r.text)
-
 # generate the embedding
 from sgtsnepi import sgtsnepi
 Y = sgtsnepi(A, d = 3, λ = 10, max_iter = 500)

--- a/python/test_digits.py
+++ b/python/test_digits.py
@@ -37,7 +37,7 @@ sys.path.insert(0,"./")
 from sgtsnepi import sgtsnepi
 Y = sgtsnepi(A, d = 3, λ = 10, max_iter = 500)
 
-# visualization
+# visualization -- require matplotlib package
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 import numpy as np
@@ -69,5 +69,5 @@ plt.show()
 
 ## AUTHOR
 # Tiancheng Liu <tcliu@cs.duke.edu>
-# Dimitris Foloros <fcdimitr@auth.gr>
+# Dimitris Floros <fcdimitr@auth.gr>
 # 


### PR DESCRIPTION
The test script generates a 3-D embedding of the kNN graph of 10 digits.

Prerequisite: the python script sgtsnepi.py is in the current folder, and PyJulia is correctly configured.

Data source:
[optdigits_10NN](https://sparse.tamu.edu/ML_Graph/optdigits_10NN)