### PR TITLE
fixed issues regarding linking fftw_parallel

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,6 +82,33 @@ foreach l : required_lib_deps
   libs_dep_dict += {l[0] : buf_dep}
 endforeach
 
+# parallel FFTW library
+fftw_par_dep = dependency('fftw3_' + get_option('fftw_parallel_lib'),
+                          required : true)
+if not fftw_par_dep.found()
+  fftw_par_dep = cc.find_library('fftw3_' + get_option('fftw_parallel_lib'),
+                                 required : true)
+endif
+if not fftw_par_dep.found()
+  error('Could not find fftw3_' + get_option('fftw_parallel_lib') + ' library.')
+endif
+
+fftwf_par_dep = dependency('fftw3f_' + get_option('fftw_parallel_lib'),
+                          required : true)
+if not fftwf_par_dep.found()
+  fftwf_par_dep = cc.find_library('fftw3f_' + get_option('fftw_parallel_lib'),
+                                 required : true)
+endif
+if not fftwf_par_dep.found()
+  error('Could not find fftw3f_' + get_option('fftw_parallel_lib') + ' library.')
+endif
+
+libs_dep = [fftw_par_dep] + [fftwf_par_dep] + libs_dep 
+# NOTE -lfftw3_<parallel> should precede -lfftw3
+libs_dep_dict += {'fftw3_parallel' : fftw_par_dep,
+                  'fftw3f_parallel' : fftwf_par_dep}
+
+
 # ========== build targets
 
 # source files

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,9 @@ option('print_times',
        type : 'boolean',
        value : false,
        description : 'Print module times?')
+option('fftw_parallel_lib',
+       type : 'combo',
+       choices : ['threads', 'omp'],
+       value : 'threads',
+       description : 'Parallel FFTW3 library implementation suffix (use single-threaded FFTW if empty)')
+

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -164,16 +164,9 @@ int getWorkers(){
 }
 
 void setWorkers(int n){
-  #ifdef OPENCILK
-  char str[4];
-  
-  sprintf( str, "%d", n );
-
-  __cilkrts_end_cilk();
-  if ( 0!=__cilkrts_set_param("nworkers", str ) )
-    std::cerr << "Error setting workers" << std::endl;
-  #else
-  #endif
+  // this function does nothing, it only exists for backwards-compatibility.
+  // if you want to set the number of OpenCilk workers do it via setting 
+  // the enviromental variable CILK_NWORKERS
 }
 
 double * readXfromMTX( const char *filename, int *n, int *d ){


### PR DESCRIPTION
updated `meson.build` to properly link `fftw3_threads` or `fftw3_omp` depending on the meson option `fftw_parallel_lib` and similarly for `fftw3f_threads` or `fftw3f_omp`

also removed the contents of `setWorkers` in `src/utils.cpp` which now only exists for backwards-compatibility