### PR TITLE
made fftw parallel lib optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,31 +83,42 @@ foreach l : required_lib_deps
 endforeach
 
 # parallel FFTW library
-fftw_par_dep = dependency('fftw3_' + get_option('fftw_parallel_lib'),
-                          required : true)
-if not fftw_par_dep.found()
-  fftw_par_dep = cc.find_library('fftw3_' + get_option('fftw_parallel_lib'),
-                                 required : true)
-endif
-if not fftw_par_dep.found()
-  error('Could not find fftw3_' + get_option('fftw_parallel_lib') + ' library.')
-endif
+if not ['', 'none'].contains(get_option('fftw_parallel_lib'))
+  fftw_par_dep = dependency('fftw3_' + get_option('fftw_parallel_lib'),
+                            required : false)
+  fftwf_par_dep = dependency('fftw3f_' + get_option('fftw_parallel_lib'),
+                            required : true)
 
-fftwf_par_dep = dependency('fftw3f_' + get_option('fftw_parallel_lib'),
-                          required : true)
-if not fftwf_par_dep.found()
-  fftwf_par_dep = cc.find_library('fftw3f_' + get_option('fftw_parallel_lib'),
-                                 required : true)
+  if not fftw_par_dep.found()
+    fftw_par_dep = cc.find_library('fftw3_' + get_option('fftw_parallel_lib'),
+                                   required : false)
+  endif
+
+  if not fftwf_par_dep.found()
+    fftwf_par_dep = cc.find_library('fftw3f_' + get_option('fftw_parallel_lib'),
+                                   required : true)
+  endif
+
+  if not fftw_par_dep.found()
+    warning('Could not find fftw3_' + get_option('fftw_parallel_lib') + 'library.' +
+            ' Using single-threaded FFTW3 execution.')
+  endif
+  if not fftwf_par_dep.found()
+    warning('Could not find fftw3f_' + get_option('fftw_parallel_lib') + ' library.' +
+            ' Using single-threaded FFTW3 execution.')
+  endif
+else
+  fftw_par_dep = dependency('', required : false)
+  fftwf_par_dep = dependency('', required : false)
 endif
-if not fftwf_par_dep.found()
-  error('Could not find fftw3f_' + get_option('fftw_parallel_lib') + ' library.')
+if not (fftw_par_dep.found() and fftwf_par_dep.found())
+  add_project_arguments(['-DFFTW_NO_PARALLEL'], language : 'cpp')
 endif
 
 libs_dep = [fftw_par_dep] + [fftwf_par_dep] + libs_dep 
 # NOTE -lfftw3_<parallel> should precede -lfftw3
 libs_dep_dict += {'fftw3_parallel' : fftw_par_dep,
                   'fftw3f_parallel' : fftwf_par_dep}
-
 
 # ========== build targets
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,7 +8,7 @@ option('print_times',
        description : 'Print module times?')
 option('fftw_parallel_lib',
        type : 'combo',
-       choices : ['threads', 'omp'],
-       value : 'threads',
+       choices : ['', 'none', 'threads', 'omp'],
+       value : '',
        description : 'Parallel FFTW3 library implementation suffix (use single-threaded FFTW if empty)')
 

--- a/src/gradient_descend.cpp
+++ b/src/gradient_descend.cpp
@@ -215,10 +215,12 @@ void kl_minimization(coord* y,
   coord zeta = 0;
 
   // ----- setup parallel FFTW
+#ifndef FFTW_NO_PARALLEL
   fftw_init_threads();
   fftw_plan_with_nthreads( params.np );
   fftwf_init_threads();
   fftwf_plan_with_nthreads( params.np );
+#endif
 
   if ( params.fftw_single )
     std::cout << "Setting-up parallel (single-precision) FFTW: " << params.np << std::endl;

--- a/src/non_periodic_conv.cpp
+++ b/src/non_periodic_conv.cpp
@@ -81,7 +81,7 @@ void conv1dnopad( double * const PhiGrid,
   wc = reinterpret_cast<std::complex<double> *> (w);
   
   // get twiddle factors
-  CILK_FOR (int i=0; i<nGridDims[0]; i++)
+  CILK_FOR (uint32_t i=0; i<nGridDims[0]; i++)
     wc[i] = std::polar(1.0, -2*pi*i/(2*nGridDims[0]) );
 
   
@@ -92,7 +92,11 @@ void conv1dnopad( double * const PhiGrid,
 
   // ~~~~~~~~~~~~~~~~~~~~ SETUP PARALLELISM
 
-
+#ifndef FFTW_NO_PARALLEL
+  fftw_init_threads();
+  fftw_plan_with_nthreads(nProc);
+#endif
+  
   
   // ~~~~~~~~~~~~~~~~~~~~ SETUP FFTW PLANS
 
@@ -114,7 +118,7 @@ void conv1dnopad( double * const PhiGrid,
     
   // ~~~~~~~~~~~~~~~~~~~~ SETUP KERNEL
   
-  for (int i=0; i<n1; i++) {
+  for (uint32_t i=0; i<n1; i++) {
     std::complex<double> tmp( kernel1d( hsq, i ), 0 );
              Kc[i]    += tmp;
     if (i>0) Kc[n1-i] += tmp;
@@ -122,8 +126,8 @@ void conv1dnopad( double * const PhiGrid,
 
   // ~~~~~~~~~~~~~~~~~~~~ SETUP RHS
   
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t i=0; i<n1; i++) {
       Xc[ SUB2IND2D(i, iVec ,n1) ] =
         VGrid[ SUB2IND2D(i, iVec, n1) ];
     }
@@ -137,8 +141,8 @@ void conv1dnopad( double * const PhiGrid,
   fftw_execute(planc_rhs);
 
   // ~~~~~~~~~~~~~~~~~~~~ HADAMARD PRODUCT
-  for (int jVec=0; jVec<nVec; jVec++) {
-    for (int i=0; i<n1; i++){
+  for (uint32_t jVec=0; jVec<nVec; jVec++) {
+    for (uint32_t i=0; i<n1; i++){
       Xc[SUB2IND2D(i,jVec,n1)] = Xc[SUB2IND2D(i,jVec,n1)] *
         Kc[i];
     }
@@ -149,8 +153,8 @@ void conv1dnopad( double * const PhiGrid,
 
   // ---------- (no conjugate multiplication)
   
-  for (int iVec=0; iVec<nVec; iVec++){
-    for (int i=0; i<n1; i++){
+  for (uint32_t iVec=0; iVec<nVec; iVec++){
+    for (uint32_t i=0; i<n1; i++){
       PhiGrid[ SUB2IND2D(i, iVec, n1) ] =
         Xc[ SUB2IND2D(i, iVec, n1) ].real();
     }
@@ -164,20 +168,20 @@ void conv1dnopad( double * const PhiGrid,
   CILK_FOR (long int i = 0; i < n1*nVec; i++)
     Xc[i] = 0.0;
   // ~~~~~~~~~~~~~~~~~~~~ SETUP KERNEL
-  for (int i=0; i<n1; i++) {
+  for (uint32_t i=0; i<n1; i++) {
     std::complex<double> tmp( kernel1d( hsq, i ), 0 );
              Kc[i]    += tmp;
     if (i>0) Kc[n1-i] -= tmp;
   }
 
-  for (int i=0; i<n1; i++) {
+  for (uint32_t i=0; i<n1; i++) {
     Kc[i] *= wc[i];
   }
 
   // ~~~~~~~~~~~~~~~~~~~~ SETUP RHS
 
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t i=0; i<n1; i++) {
       Xc[ SUB2IND2D(i, iVec ,n1) ] =
         VGrid[ SUB2IND2D(i, iVec, n1) ] * wc[i];
     }
@@ -190,8 +194,8 @@ void conv1dnopad( double * const PhiGrid,
   fftw_execute(planc_rhs);
 
   // ~~~~~~~~~~~~~~~~~~~~ HADAMARD PRODUCT
-  for (int jVec=0; jVec<nVec; jVec++) {
-    for (int i=0; i<n1; i++){
+  for (uint32_t jVec=0; jVec<nVec; jVec++) {
+    for (uint32_t i=0; i<n1; i++){
       Xc[SUB2IND2D(i,jVec,n1)] = Xc[SUB2IND2D(i,jVec,n1)] *
         Kc[i];
     }
@@ -202,16 +206,16 @@ void conv1dnopad( double * const PhiGrid,
 
   
   // ---------- data normalization
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t i=0; i<n1; i++) {
       Xc[ SUB2IND2D(i, iVec, n1) ] =
         Xc[ SUB2IND2D(i, iVec, n1) ] *
         std::conj(wc[i]);
     }
   }
   
-  for (int iVec=0; iVec<nVec; iVec++){
-    for (int i=0; i<n1; i++){
+  for (uint32_t iVec=0; iVec<nVec; iVec++){
+    for (uint32_t i=0; i<n1; i++){
       PhiGrid[ SUB2IND2D(i, iVec, n1) ] +=
         Xc[ SUB2IND2D(i, iVec, n1) ].real();
     }
@@ -224,7 +228,10 @@ void conv1dnopad( double * const PhiGrid,
   fftw_destroy_plan( planc_kernel );
   fftw_destroy_plan( planc_rhs );
   fftw_destroy_plan( planc_inverse );
-
+#ifndef FFTW_NO_PARALLEL
+  fftw_cleanup_threads();
+#endif
+  
   // ~~~~~~~~~~~~~~~~~~~~ DE-ALLOCATE MEMORIES
   fftw_free( K );
   fftw_free( X );
@@ -272,7 +279,7 @@ void conv2dnopad( double * const PhiGrid,
   wc = reinterpret_cast<std::complex<double> *> (w);
 
   // get twiddle factors
-  CILK_FOR (int i=0; i<nGridDims[0]; i++)
+  CILK_FOR (uint32_t i=0; i<nGridDims[0]; i++)
     wc[i] = std::polar(1.0, -2*pi*i/(2*nGridDims[0]) );
   
   CILK_FOR (long int i = 0; i < n1*n2; i++)
@@ -282,7 +289,11 @@ void conv2dnopad( double * const PhiGrid,
 
   // ~~~~~~~~~~~~~~~~~~~~ SETUP PARALLELISM
 
-
+#ifndef FFTW_NO_PARALLEL
+  fftw_init_threads();
+  fftw_plan_with_nthreads(nProc);
+#endif
+  
   // ~~~~~~~~~~~~~~~~~~~~ SETUP FFTW PLANS
 
   planc_kernel = fftw_plan_dft_2d(n1, n2, K, K, FFTW_FORWARD, FFTW_ESTIMATE);
@@ -302,8 +313,8 @@ void conv2dnopad( double * const PhiGrid,
   // ============================== EVEN-EVEN
   
   // ~~~~~~~~~~~~~~~~~~~~ SETUP KERNEL
-  for (int j=0; j<n2; j++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t j=0; j<n2; j++) {
+    for (uint32_t i=0; i<n1; i++) {
       std::complex<double> tmp( kernel2d( hsq, i, j ), 0 );
       Kc[SUB2IND2D(i,j,n1)]      += tmp;
       if (i>0) Kc[SUB2IND2D(n1-i,j,n1)] += tmp;
@@ -313,9 +324,9 @@ void conv2dnopad( double * const PhiGrid,
   }
   
   // ~~~~~~~~~~~~~~~~~~~~ SETUP RHS
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int j=0; j<n2; j++) {
-      for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t j=0; j<n2; j++) {
+      for (uint32_t i=0; i<n1; i++) {
         Xc[ SUB2IND3D(i, j, iVec ,n1, n2) ] =
           VGrid[ SUB2IND3D(i, j, iVec, n1, n2) ];
       }
@@ -330,9 +341,9 @@ void conv2dnopad( double * const PhiGrid,
   fftw_execute(planc_rhs);
 
   // ~~~~~~~~~~~~~~~~~~~~ HADAMARD PRODUCT
-  for (int jVec=0; jVec<nVec; jVec++) {
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t jVec=0; jVec<nVec; jVec++) {
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         Xc[SUB2IND3D(i,j,jVec,n1,n2)] = Xc[SUB2IND3D(i,j,jVec,n1,n2)] *
           Kc[SUB2IND2D(i,j,n1)];
       }
@@ -344,9 +355,9 @@ void conv2dnopad( double * const PhiGrid,
 
   // ---------- (no conjugate multiplication)
 
-  for (int iVec=0; iVec<nVec; iVec++){
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t iVec=0; iVec<nVec; iVec++){
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         PhiGrid[ SUB2IND3D(i, j, iVec, n1, n2) ] =
           Xc[ SUB2IND3D(i, j, iVec, n1, n2) ].real();
       }
@@ -361,8 +372,8 @@ void conv2dnopad( double * const PhiGrid,
   CILK_FOR (long int i = 0; i < n1*n2*nVec; i++)
     Xc[i] = 0.0;
   // ~~~~~~~~~~~~~~~~~~~~ SETUP KERNEL
-  for (int j=0; j<n2; j++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t j=0; j<n2; j++) {
+    for (uint32_t i=0; i<n1; i++) {
       std::complex<double> tmp( kernel2d( hsq, i, j ), 0 );
       Kc[SUB2IND2D(i,j,n1)]      += tmp;
       if (i>0) Kc[SUB2IND2D(n1-i,j,n1)] -= tmp;
@@ -372,16 +383,16 @@ void conv2dnopad( double * const PhiGrid,
   }
 
   
-  for (int j=0; j<n2; j++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t j=0; j<n2; j++) {
+    for (uint32_t i=0; i<n1; i++) {
       Kc[SUB2IND2D(i,j,n1)] *= wc[i];
     }
   }
   
   // ~~~~~~~~~~~~~~~~~~~~ SETUP RHS
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int j=0; j<n2; j++) {
-      for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t j=0; j<n2; j++) {
+      for (uint32_t i=0; i<n1; i++) {
         Xc[ SUB2IND3D(i, j, iVec ,n1, n2) ] =
           VGrid[ SUB2IND3D(i, j, iVec, n1, n2) ] * wc[i];
       }
@@ -396,9 +407,9 @@ void conv2dnopad( double * const PhiGrid,
   fftw_execute(planc_rhs);
 
   // ~~~~~~~~~~~~~~~~~~~~ HADAMARD PRODUCT
-  for (int jVec=0; jVec<nVec; jVec++) {
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t jVec=0; jVec<nVec; jVec++) {
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         Xc[SUB2IND3D(i,j,jVec,n1,n2)] = Xc[SUB2IND3D(i,j,jVec,n1,n2)] *
           Kc[SUB2IND2D(i,j,n1)];
       }
@@ -409,9 +420,9 @@ void conv2dnopad( double * const PhiGrid,
   fftw_execute(planc_inverse);
 
   // ---------- data normalization
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int j=0; j<n2; j++) {
-      for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t j=0; j<n2; j++) {
+      for (uint32_t i=0; i<n1; i++) {
         Xc[ SUB2IND3D(i, j, iVec, n1,n2) ] =
           Xc[ SUB2IND3D(i, j,iVec, n1,n2) ] *
           std::conj(wc[i]);
@@ -419,9 +430,9 @@ void conv2dnopad( double * const PhiGrid,
     }
   }
 
-  for (int iVec=0; iVec<nVec; iVec++){
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t iVec=0; iVec<nVec; iVec++){
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         PhiGrid[ SUB2IND3D(i, j, iVec, n1, n2) ] +=
           Xc[ SUB2IND3D(i, j, iVec, n1, n2) ].real();
       }
@@ -437,8 +448,8 @@ void conv2dnopad( double * const PhiGrid,
   CILK_FOR (long int i = 0; i < n1*n2*nVec; i++)
     Xc[i] = 0.0;
   // ~~~~~~~~~~~~~~~~~~~~ SETUP KERNEL
-  for (int j=0; j<n2; j++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t j=0; j<n2; j++) {
+    for (uint32_t i=0; i<n1; i++) {
       std::complex<double> tmp( kernel2d( hsq, i, j ), 0 );
       Kc[SUB2IND2D(i,j,n1)]      += tmp;
       if (i>0) Kc[SUB2IND2D(n1-i,j,n1)] += tmp;
@@ -448,16 +459,16 @@ void conv2dnopad( double * const PhiGrid,
   }
 
   
-  for (int j=0; j<n2; j++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t j=0; j<n2; j++) {
+    for (uint32_t i=0; i<n1; i++) {
       Kc[SUB2IND2D(i,j,n1)] *= wc[j];
     }
   }
   
   // ~~~~~~~~~~~~~~~~~~~~ SETUP RHS
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int j=0; j<n2; j++) {
-      for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t j=0; j<n2; j++) {
+      for (uint32_t i=0; i<n1; i++) {
         Xc[ SUB2IND3D(i, j, iVec ,n1, n2) ] =
           VGrid[ SUB2IND3D(i, j, iVec, n1, n2) ] * wc[j];
       }
@@ -472,9 +483,9 @@ void conv2dnopad( double * const PhiGrid,
   fftw_execute(planc_rhs);
 
   // ~~~~~~~~~~~~~~~~~~~~ HADAMARD PRODUCT
-  for (int jVec=0; jVec<nVec; jVec++) {
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t jVec=0; jVec<nVec; jVec++) {
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         Xc[SUB2IND3D(i,j,jVec,n1,n2)] = Xc[SUB2IND3D(i,j,jVec,n1,n2)] *
           Kc[SUB2IND2D(i,j,n1)];
       }
@@ -485,9 +496,9 @@ void conv2dnopad( double * const PhiGrid,
   fftw_execute(planc_inverse);
 
   // ---------- data normalization
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int j=0; j<n2; j++) {
-      for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t j=0; j<n2; j++) {
+      for (uint32_t i=0; i<n1; i++) {
         Xc[ SUB2IND3D(i, j, iVec, n1,n2) ] =
           Xc[ SUB2IND3D(i, j,iVec, n1,n2) ] *
           std::conj(wc[j]);
@@ -495,9 +506,9 @@ void conv2dnopad( double * const PhiGrid,
     }
   }
 
-  for (int iVec=0; iVec<nVec; iVec++){
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t iVec=0; iVec<nVec; iVec++){
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         PhiGrid[ SUB2IND3D(i, j, iVec, n1, n2) ] +=
           Xc[ SUB2IND3D(i, j, iVec, n1, n2) ].real();
       }
@@ -513,8 +524,8 @@ void conv2dnopad( double * const PhiGrid,
   CILK_FOR (long int i = 0; i < n1*n2*nVec; i++)
     Xc[i] = 0.0;
   // ~~~~~~~~~~~~~~~~~~~~ SETUP KERNEL
-  for (int j=0; j<n2; j++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t j=0; j<n2; j++) {
+    for (uint32_t i=0; i<n1; i++) {
       std::complex<double> tmp( kernel2d( hsq, i, j ), 0 );
       Kc[SUB2IND2D(i,j,n1)]      += tmp;
       if (i>0) Kc[SUB2IND2D(n1-i,j,n1)] -= tmp;
@@ -522,16 +533,16 @@ void conv2dnopad( double * const PhiGrid,
       if (i>0 && j>0) Kc[SUB2IND2D(n1-i,n2-j,n1)] += tmp;
     }
   }
-  for (int j=0; j<n2; j++) {
-    for (int i=0; i<n1; i++) {
+  for (uint32_t j=0; j<n2; j++) {
+    for (uint32_t i=0; i<n1; i++) {
       Kc[SUB2IND2D(i,j,n1)] *= wc[j]*wc[i];
     }
   }
   
   // ~~~~~~~~~~~~~~~~~~~~ SETUP RHS
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int j=0; j<n2; j++) {
-      for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t j=0; j<n2; j++) {
+      for (uint32_t i=0; i<n1; i++) {
         Xc[ SUB2IND3D(i, j, iVec ,n1, n2) ] =
           VGrid[ SUB2IND3D(i, j, iVec, n1, n2) ] * wc[j] * wc[i];
       }
@@ -546,9 +557,9 @@ void conv2dnopad( double * const PhiGrid,
   fftw_execute(planc_rhs);
 
   // ~~~~~~~~~~~~~~~~~~~~ HADAMARD PRODUCT
-  for (int jVec=0; jVec<nVec; jVec++) {
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t jVec=0; jVec<nVec; jVec++) {
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         Xc[SUB2IND3D(i,j,jVec,n1,n2)] = Xc[SUB2IND3D(i,j,jVec,n1,n2)] *
           Kc[SUB2IND2D(i,j,n1)];
       }
@@ -559,9 +570,9 @@ void conv2dnopad( double * const PhiGrid,
   fftw_execute(planc_inverse);
 
   // ---------- data normalization
-  for (int iVec=0; iVec<nVec; iVec++) {
-    for (int j=0; j<n2; j++) {
-      for (int i=0; i<n1; i++) {
+  for (uint32_t iVec=0; iVec<nVec; iVec++) {
+    for (uint32_t j=0; j<n2; j++) {
+      for (uint32_t i=0; i<n1; i++) {
         Xc[ SUB2IND3D(i, j, iVec, n1,n2) ] =
           Xc[ SUB2IND3D(i, j,iVec, n1,n2) ] *
           std::conj(wc[i]) * std::conj(wc[j]);
@@ -569,18 +580,18 @@ void conv2dnopad( double * const PhiGrid,
     }
   }
 
-  for (int iVec=0; iVec<nVec; iVec++){
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t iVec=0; iVec<nVec; iVec++){
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         PhiGrid[ SUB2IND3D(i, j, iVec, n1, n2) ] +=
           Xc[ SUB2IND3D(i, j, iVec, n1, n2) ].real();
       }
     }
   }
   
-  for (int iVec=0; iVec<nVec; iVec++){
-    for (int j=0; j<n2; j++){
-      for (int i=0; i<n1; i++){
+  for (uint32_t iVec=0; iVec<nVec; iVec++){
+    for (uint32_t j=0; j<n2; j++){
+      for (uint32_t i=0; i<n1; i++){
         PhiGrid[ SUB2IND3D(i, j, iVec, n1, n2) ] *= 0.25 / ((double) n1*n2);
       }
     }
@@ -591,6 +602,9 @@ void conv2dnopad( double * const PhiGrid,
   fftw_destroy_plan( planc_kernel );
   fftw_destroy_plan( planc_rhs );
   fftw_destroy_plan( planc_inverse );
+#ifndef FFTW_NO_PARALLEL
+  fftw_cleanup_threads();
+#endif
 
   // ~~~~~~~~~~~~~~~~~~~~ DE-ALLOCATE MEMORIES
   fftw_free( K );
@@ -607,9 +621,10 @@ void conv3dnopad( double * const PhiGrid,
                   const uint32_t nDim,
                   const uint32_t nProc ) {
 
+  
   struct timeval start;
   start = tsne_start_timer();
-
+  
   // ~~~~~~~~~~~~~~~~~~~~ DEFINE VARIABLES
   fftw_complex *K, *X, *w;
   std::complex<double> *Kc, *Xc, *wc;
@@ -642,7 +657,7 @@ void conv3dnopad( double * const PhiGrid,
   wc = reinterpret_cast<std::complex<double> *> (w);
 
   // get twiddle factors
-  CILK_FOR (int i=0; i<nGridDims[0]; i++)
+  CILK_FOR (uint32_t i=0; i<nGridDims[0]; i++)
     wc[i] = std::polar(1.0, -2*pi*i/(2*nGridDims[0]) );
   
   CILK_FOR (long int i = 0; i < n1*n2*n3; i++)
@@ -653,6 +668,11 @@ void conv3dnopad( double * const PhiGrid,
   // ~~~~~~~~~~~~~~~~~~~~ SETUP PARALLELISM
   tsne_stop_timer("init", start); start = tsne_start_timer();
 
+#ifndef FFTW_NO_PARALLEL
+  fftw_init_threads();
+  fftw_plan_with_nthreads(nProc);
+#endif
+  
   // ~~~~~~~~~~~~~~~~~~~~ SETUP FFTW PLANS
 
   planc_kernel = fftw_plan_dft_3d(n1, n2, n3, K, K, FFTW_FORWARD, FFTW_ESTIMATE);
@@ -721,10 +741,10 @@ void conv3dnopad( double * const PhiGrid,
   tsne_stop_timer("ooo", start); start = tsne_start_timer();
 
 
-  for (int iVec=0; iVec<nVec; iVec++){
-    for (int k=0; k<n3; k++){
-      for (int j=0; j<n2; j++){
-        for (int i=0; i<n1; i++){
+  for (uint32_t iVec=0; iVec<nVec; iVec++){
+    for (uint32_t k=0; k<n3; k++){
+      for (uint32_t j=0; j<n2; j++){
+        for (uint32_t i=0; i<n1; i++){
           PhiGrid[ SUB2IND4D(i, j, k, iVec, n1, n2, n3) ] *= 0.125 / ((double) n1*n2*n3);
         }
       }
@@ -737,13 +757,15 @@ void conv3dnopad( double * const PhiGrid,
   fftw_destroy_plan( planc_kernel );
   fftw_destroy_plan( planc_rhs );
   fftw_destroy_plan( planc_inverse );
-
+#ifndef FFTW_NO_PARALLEL
+  fftw_cleanup_threads();
+#endif
+  
   // ~~~~~~~~~~~~~~~~~~~~ DE-ALLOCATE MEMORIES
   fftw_free( K );
   fftw_free( X );
   fftw_free( w );
 
   tsne_stop_timer("destroy", start); start = tsne_start_timer();
-
 }
 }


### PR DESCRIPTION
Made FFTW parallel library optional like in branch `v3.0.0`.

`meson.build` now adds a C preprocessor macro `FFTW_NO_PARALLEL` that can be used in the code to only include FFTW parallel functions when the parallel libraries are being used.